### PR TITLE
heroku: Procfile added, deploy to heroku button added

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: npm start

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Join the chat at https://gitter.im/steida/este-todomvc](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/steida/este-todomvc)
 [![Dependency Status](https://david-dm.org/steida/este-todomvc.png)](https://david-dm.org/steida/este-todomvc)
 [![devDependency Status](https://david-dm.org/steida/este-todomvc/dev-status.png)](https://david-dm.org/steida/este-todomvc#info=devDependencies)
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
 
 > ES6 React Flux webpack gulp om-like isomorphic immutable k̶i̶t̶c̶h̶e̶n̶s̶i̶n̶k̶ t̶w̶e̶e̶t̶y̶b̶i̶r̶d̶s̶ edition.
 

--- a/app.json
+++ b/app.json
@@ -1,0 +1,7 @@
+{
+  "name": "este-todomvc",
+  "description": "este-todomvc",
+  "repository": "https://github.com/steida/este-todomvc",
+  "logo": "https://cloud.githubusercontent.com/assets/66249/5931133/9e973dfc-a699-11e4-83bc-7b5c6fb58bfd.jpeg",
+  "keywords": ["node", "reactjs", "este", "todomvc"]
+}


### PR DESCRIPTION
Closes #5

Heroku Procfile added - using npm start to start production mode.
Deploy to Heroku button added to README. (app.json need to be added) (button will work across forks and branches - using referer header)