### PR TITLE
Update sass-loader to 1.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "react-hot-loader": "^1.1.4",
     "react-router": "^0.12.0",
     "run-sequence": "^1.0.2",
-    "sass-loader": "^0.4.0-beta.1",
+    "sass-loader": "^1.0.2",
     "style-loader": "^0.8.3",
     "stylus-loader": "^0.6.0",
     "todomvc-app-css": "^1.0.0",


### PR DESCRIPTION
node-sass, which is a sass-loaded dependency get fixed issues with musl libc (used in Alpine Linux) native compilation in a recent release.